### PR TITLE
Add flags to customize output

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ exit status 2
       Password (Optional)
   --critical-on-missing
       Return CRITICAL if query results are missing (Optional) (default "no")
+  --max-chars
+      Max. count of characters to print
+  --print-details
+      Prints all returned values on multiline result
   --value-mapping string
     	Mapping result metrics for output (Optional, json i.e. '{"0":"down","1":"up"}')
   --value-unit string

--- a/nagitheus.go
+++ b/nagitheus.go
@@ -39,7 +39,7 @@ const (
 	WARNING          = 1
 	CRITICAL         = 2
 	UNKNOWN          = 3
-	NagitheusVersion = "1.3.0"
+	NagitheusVersion = "1.4.0"
 )
 
 var NagiosMessage struct {


### PR DESCRIPTION
A new flag called `--print-details` was added. It can be used in order to print all lines when a multiline result was returned. If this flag is not provided, only the summary of the status message will be printed.

A new flag called `--max-chars` was added. It can be used to limit the number of characters that should be printed. No default value is missing. Therefore if the flag is not provided, the whole status message will be printed. Error messages can not be limited.