### PR TITLE
Add performance time

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ exit status 2
       Max. count of characters to print
   --print-details
       Prints all returned values on multiline result
+  --print-perf-data
+	    Prints performance data for results in the format `query_result=<result>;<warning>;<critical>`
   --value-mapping string
     	Mapping result metrics for output (Optional, json i.e. '{"0":"down","1":"up"}')
   --value-unit string

--- a/nagitheus.go
+++ b/nagitheus.go
@@ -135,7 +135,7 @@ func main() {
 
 	if len(*format) == 0 {
 		if *perf_data {
-			*format = "{{.Label}} is {{.Value}} | query_result={{.Value}};0:{{.Warning}};0:{{.Critical}}"
+			*format = "{{.Label}} is {{.Value}} | query_result={{.Value}};{{.Warning}};{{.Critical}}"
 		} else {
 			*format = "{{.Label}} is {{.Value}}"
 		}

--- a/nagitheus.go
+++ b/nagitheus.go
@@ -135,7 +135,7 @@ func main() {
 
 	if len(*format) == 0 {
 		if *perf_data {
-			*format = "{{.Label}} is {{.Value}} | query_result={{.Value}};0:{{.Warning}};0:{{.Critical}};U;U"
+			*format = "{{.Label}} is {{.Value}} | query_result={{.Value}};0:{{.Warning}};0:{{.Critical}}"
 		} else {
 			*format = "{{.Label}} is {{.Value}}"
 		}


### PR DESCRIPTION
Providing the flag `--print-perf-data` the performance data of the result is printed. It has the format of `query_result=<result>;<warning>;<critical>` and can be used for generating result graphs